### PR TITLE
Add buttons to copy installation commands

### DIFF
--- a/source/css/bootstrap-customize.css.scss
+++ b/source/css/bootstrap-customize.css.scss
@@ -21,6 +21,8 @@ $headings-color: $medium-light;
 $input-border-focus: $medium-light;
 $progress-bg: #4f2843;
 $progress-bar-bg: #ffab29;
+$tooltip-bg: $medium;
+$tooltip-arrow-width: 8px;
 
 $text-color:            $violet-menu !default;
 

--- a/source/css/download.css.scss
+++ b/source/css/download.css.scss
@@ -120,11 +120,15 @@ $colors: (
             padding: 0px 10px 0px 0;
             
             .command {
+              border: 0;
               border-radius: 4px;
-              padding: 15px 25px;
               font-family: $font-family-monospace;
               background-color: $pink-bg-light;
               color: #6e5465;
+
+              &.desktop-command {
+                padding: 15px 25px;
+              }
             }
           }
 
@@ -156,7 +160,8 @@ $colors: (
 
         .form-control {
           width: 400px;
-          padding: 25px 20px;
+          height: 46px;
+          line-height: 20px;
         }
 
         .btn {
@@ -174,6 +179,7 @@ $colors: (
     padding-bottom: 3 0px;
 
     .dev-build-container {
+      margin: auto;
       max-width: 960px;
 
       h2 {

--- a/source/css/virtkick.css.scss
+++ b/source/css/virtkick.css.scss
@@ -85,6 +85,20 @@ h2.section {
   margin-bottom: 60px;
 }
 
+.tooltip {
+    @include transition(width 1.25s);
+  .tooltip-arrow {
+    border-top-color: $medium !important;
+  }
+
+  .tooltip-inner {
+    border-radius: 4px;
+    background-color: $medium;
+    font-size: 1.1em;
+    padding: 20px;
+  }
+}
+
 .page-top {
   position: relative;
 

--- a/source/download.html.slim
+++ b/source/download.html.slim
@@ -52,7 +52,7 @@ distros:
           h3 #{distro.name} installation
           - if distro.installation == 'package'
             p 
-              > To install VirtKick simply open terminal and write:
+              > To install VirtKick simply open a terminal and execute:
             .commands
               - distro.commands.each do |command|
                 .command-wrapper

--- a/source/download.html.slim
+++ b/source/download.html.slim
@@ -44,7 +44,7 @@ distros:
             .distro-square
               .distro-inner 
                 img src=distro.logo
-            p.distro-name
+            p.distro-name.hidden-xs
               #{distro.name}
     - current_page.data.distros.each do |distro|
       div class="row installation hidden #{distro.name.downcase.delete(' ').delete('.')}-installation"
@@ -57,9 +57,10 @@ distros:
               - distro.commands.each do |command|
                 .command-wrapper
                   .command-cell
-                    .command
+                    .command.desktop-command.hidden
                       #{command}
-                  .btn.btn-primary.copy.hidden
+                    input.command.mobile-command.form-control.hidden value="#{command}" data-command="#{command}"
+                  .btn.btn-primary.copy
                     .fa.fa-copy
             /!
               p
@@ -105,10 +106,10 @@ distros:
               a href="https://deploy.virtkick.io" https://deploy.virtkick.io
               > .
 
-  .dev-build-wrapper 
-    .container.dev-build-container 
-      .row
-        .col-md-12
+  .container-fluid.dev-build-wrapper
+    .row
+      .col-md-12
+        .dev-build-container
           h2 
             > Development builds
           p 
@@ -125,4 +126,17 @@ distros:
         var distro = $(this).data('distro');
         vk.download.showDistro(distro);   
       }); 
+
+      // add copy buttons behaviour
+      $('.copy').click(function () {
+        var wrapper = $(this).closest('.command-wrapper');
+
+        // select command
+        wrapper.find('.command').selectText();
+
+        // show tooltips only on desktop
+        if (!vk.mobile.check()) {
+          vk.download.showCopyTooltip(wrapper);
+        }
+      });
     });

--- a/source/js/vendor/jquery.selecttext.js
+++ b/source/js/vendor/jquery.selecttext.js
@@ -1,0 +1,18 @@
+// source: http://stackoverflow.com/questions/985272/selecting-text-in-an-element-akin-to-highlighting-with-your-mouse
+jQuery.fn.selectText = function(){
+    var doc = document
+        , element = this[0]
+        , range, selection
+    ;
+    if (doc.body.createTextRange) {
+        range = document.body.createTextRange();
+        range.moveToElementText(element);
+        range.select();
+    } else if (window.getSelection) {
+        selection = window.getSelection();        
+        range = document.createRange();
+        range.selectNodeContents(element);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+};

--- a/source/js/virtkick.js
+++ b/source/js/virtkick.js
@@ -1,6 +1,8 @@
 //= require vendor/jquery-2.1.0.min.js
+//= require vendor/jquery.selecttext.js
 //= require vendor/jquery.ajaxchimp-1.3.0.js
 //= require vendor/cover-pop.js
 //= require bootstrap
+//= require virtkick/mobile.js
 //= require virtkick/popup.js
 //= require virtkick/download.js

--- a/source/js/virtkick/download.js
+++ b/source/js/virtkick/download.js
@@ -11,8 +11,48 @@ vk.download = (function () {
     }
   };
   return {
+    showCopyTooltip: function (elem) {
+      // show tooltip
+      elem.tooltip({
+        placement: 'top',
+        trigger: 'manual',
+        title: 'Press ctrl + C to copy',
+        template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"><p></p></div></div>'
+      });
+      elem.tooltip('show');
+
+      // if ctrl + c detected
+      $(document).keypress("c",function (e) {
+        if (e.ctrlKey) {
+          var tooltipInner = $('.' + currentDistro + '-installation').find('.tooltip-inner');
+          var copiedMsg = '<span class="fa fa-check"></span> Copied!';
+          tooltipInner.width(tooltipInner.width());
+          tooltipInner.html(copiedMsg);
+        }
+      });
+
+      // on clicking anywhere hide tooltip
+      var hideTooltip = function () {
+        elem.tooltip('hide');
+        $(document).unbind('mouseup', hideTooltip);
+      }
+
+      $(document).mouseup(hideTooltip);
+    },
     showDistro: function (distro) {
       if (currentDistro !== distro) {
+        if (vk.mobile.check()) {
+            $('.' + distro + '-installation .copy').addClass('hidden');
+
+            var mobileCommandElem = $('.' + distro + '-installation .mobile-command');
+            mobileCommandElem.removeClass('hidden');
+            mobileCommandElem.change(function () {
+              var command = mobileCommandElem.data('command');
+              mobileCommandElem.val(command);
+            });
+        } else {
+          $('.' + distro + '-installation .desktop-command').removeClass('hidden');
+        }
         hideDistro(currentDistro);
         $('.' + distro).addClass('active');
         $('.' + distro + '-installation').removeClass('hidden');

--- a/source/js/virtkick/mobile.js
+++ b/source/js/virtkick/mobile.js
@@ -1,0 +1,18 @@
+// create namespace
+if (!vk) var vk = {};
+
+vk.mobile = (function () {
+  var isMobile = undefined;
+
+  return {
+    check: function () {
+      if (isMobile === undefined) {
+        isMobile = false;
+        // source: detectmobilebrowsers.com
+        (function(a,b){if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4)))isMobile = true;})(navigator.userAgent||navigator.vendor||window.opera,'http://detectmobilebrowser.com/mobile');
+      }
+      return isMobile;
+    }
+  }
+})();
+


### PR DESCRIPTION
This PR is for adding buttons described in #26:

![screenshot from 2015-01-01 20 51 40](https://cloud.githubusercontent.com/assets/3458255/5593132/10d83292-91f8-11e4-8a84-6daddecb8016.png)

Above is for desktop users (detected using lib from http://detectmobilebrowsers.com/)

Mobile users has commands wrapped in <input> tags which makes them easier to copy manualy.