### PR TITLE
redesign legal subpage, fixes #35

### DIFF
--- a/source/css/legal.css.scss
+++ b/source/css/legal.css.scss
@@ -1,0 +1,23 @@
+@import 'bootstrap-customize';
+@import '_mixins';
+
+#page-legal {
+  .page-top {    
+    padding-bottom: 65px;
+
+    h1 {
+      margin-top: 40px;
+      margin-bottom: 0px;
+      text-align: center;
+    }
+  }
+
+  .attributions {
+    padding-top: 0px;
+
+    .highlight {
+      font-weight: 600;
+      color: $violet-text;
+    }
+  }
+}

--- a/source/legal.html.slim
+++ b/source/legal.html.slim
@@ -1,16 +1,49 @@
 #page-legal
   .page-top.white
     = partial 'layouts/nav', locals: {logo: 'color'}
+    .container
+      .row
+        .col-md-offset-1.col-md-10
+          h1 Trademark attributions
   .container
     .row
-      h1 Trademark attributions
-
-      p VirtKick™ is a trademark of Damian Nowak.
-      p Linux® is the registered trademark of Linus Torvalds in the U.S. and other countries.
-      p Amazon Web Services is a trademark of Amazon.com, Inc. or its affiliates in the United States and/or other countries.
-      p VMware is a registered trademark or trademark of VMware, Inc. in the United States and/or other jurisdictions.
-      p The Chef™ Mark and Chef Logo are either registered trademarks/service marks or trademarks/ service marks of Chef,
-        in the United States and other countries.
-      p Docker and Docker logo are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries.
-      p GlusterFS is a registered trademark of Gluster, Inc.
-      p Ceph is a registered trademark of Inktank Storage, Inc.
+      .col-md-offset-1.col-md-10
+        .attributions
+          p 
+            span.highlight 
+              > VirtKick™ 
+            > is a trademark of Damian Nowak.
+          p 
+            span.highlight 
+              > Linux® 
+            > is the registered trademark of Linus Torvalds in the U.S. and other countries.
+          p 
+            span.highlight 
+              > Amazon Web Services
+            > is a trademark of Amazon.com, Inc. or its affiliates in the United States and/or other countries.
+          p 
+            span.highlight 
+              > VMware
+            > is a registered trademark or trademark of VMware, Inc. in the United States and/or other jurisdictions.
+          p 
+            span.highlight 
+              > The Chef™ Mark
+            > and 
+            span.highlight 
+              > Chef Logo 
+            > are either registered trademarks/service marks or trademarks/ service marks of Chef, in the United States and other countries.
+          p 
+            span.highlight 
+              > Docker 
+            > and 
+            span.highlight 
+              > Docker logo 
+            > are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries.
+          p 
+            span.highlight 
+              > GlusterFS
+            > is a registered trademark of Gluster, Inc.
+          p 
+            span.highlight 
+              > Ceph
+            > is a registered trademark of Inktank Storage, Inc.


### PR DESCRIPTION
This PR is for redesigning legal subpage as described in #35. After changes it looks like this:

![screenshot from 2015-01-19 21 01 15](https://cloud.githubusercontent.com/assets/3458255/5806971/85d17354-a01e-11e4-9ec4-542bb38cec05.png)
